### PR TITLE
Drupal core security upgrade to 7.75

### DIFF
--- a/scripts/drupal-core-7.74.sh
+++ b/scripts/drupal-core-7.74.sh
@@ -17,7 +17,8 @@ cd $SITEDIR
 drush vset maintenance_mode 1
 
 echo Applying security update
-drush up -y drupal-7.74
+drush up -y drupal-7.74 autologout-7.x-4.6 ctools-7.x-1.17 calendar-7.x-3.6 \
+    date_ical-7.x-3.10 features-7.x-2.12 views-7.x-3.24 webform-7.x-4.23
 
 echo Clearing caches twice, once is not always sufficient
 drush cc all

--- a/scripts/drupal-core-7.74.sh
+++ b/scripts/drupal-core-7.74.sh
@@ -1,0 +1,29 @@
+# Apply security update 7.74 for Drupal core.
+
+echo Verifying account running script
+if [ $(whoami) != "drupal" ]
+then
+    echo This script must be run using the drupal account.
+    echo Aborting script.
+    exit
+fi
+
+echo Setting locations
+export SITEDIR=/local/drupal/sites/ebms.nci.nih.gov
+echo "Site directory is $SITEDIR"
+
+echo Putting site into maintenance mode
+cd $SITEDIR
+drush vset maintenance_mode 1
+
+echo Applying security update
+drush up -y drupal-7.74
+
+echo Clearing caches twice, once is not always sufficient
+drush cc all
+drush cc all
+
+echo Putting site back into live mode
+drush vset maintenance_mode 0
+
+echo Done

--- a/scripts/drupal-core-7.75.sh
+++ b/scripts/drupal-core-7.75.sh
@@ -1,4 +1,4 @@
-# Apply security update 7.74 for Drupal core.
+# Apply security update 7.75 for Drupal core.
 
 echo Verifying account running script
 if [ $(whoami) != "drupal" ]
@@ -17,8 +17,8 @@ cd $SITEDIR
 drush vset maintenance_mode 1
 
 echo Applying security update
-drush up -y drupal-7.74 autologout-7.x-4.6 ctools-7.x-1.17 calendar-7.x-3.6 \
-    date_ical-7.x-3.10 features-7.x-2.12 views-7.x-3.24 webform-7.x-4.23
+drush up -y drupal-7.75 autologout-7.x-4.6 ctools-7.x-1.17 calendar-7.x-3.6 \
+    date_ical-7.x-3.10 features-7.x-2.13 views-7.x-3.24 webform-7.x-4.23
 
 echo Clearing caches twice, once is not always sufficient
 drush cc all


### PR DESCRIPTION
The upgrade failed on Wednesday evening because `drush` was broken. CBIIT isn't able to tell me how they fixed it, but it worked today and the upgrade is now on production. The branch has `drupal-core-7.74` as its name, because when it was created that was the latest Drupal core release. While we worked on testing that upgrade on the lower tiers more vulnerabilities were found and fixed with release 7.75. So we started over.