### PR TITLE
Mime type fix

### DIFF
--- a/ebms.nci.nih.gov/modules/custom/ebms/docs.inc
+++ b/ebms.nci.nih.gov/modules/custom/ebms/docs.inc
@@ -607,6 +607,8 @@ function pdq_ebms_post_doc_form_validate($form, &$form_state) {
     $word_xml = 'vnd.openxmlformats-officedocument.wordprocessingml.document';
     if ($mime_type == "application/$word_xml")
         $mime_type = 'application/msword';
+    elseif ($mime_type == 'application/CDFV2' && $extension == 'doc')
+        $mime_type = 'application/msword';
 
     // Another hoop to jump through if it's a summary document.
     if ($is_summary) {

--- a/ebms.nci.nih.gov/modules/custom/ebms/reports.inc
+++ b/ebms.nci.nih.gov/modules/custom/ebms/reports.inc
@@ -5415,6 +5415,8 @@ function pdq_ebms_doc_edit_form_validate($form, &$form_state) {
         // Workaround for shifting MS word mime types (OCEEBMS-383).
         if ($mime_type == "application/$word_xml")
             $mime_type = 'application/msword';
+        elseif ($mime_type == 'application/CDFV2' && $extension == 'doc')
+            $mime_type = 'application/msword';
 
         $expected = $acceptable[$extension];
         if ($mime_type != $expected) {


### PR DESCRIPTION
When CBIIT upgraded PHP on the Drupal 7 servers, EBMS document management was broken by a change in the mime type reported for word-processing documents stored in Microsoft's legacy format (.doc files). This patch provides a workaround for that breakage. The workaround is on all tiers.